### PR TITLE
Making DRAMFS functions visible to Cpp compiler

### DIFF
--- a/libgloss/dramfs/dramfs/littlefs/bd/lfs_bd.h
+++ b/libgloss/dramfs/dramfs/littlefs/bd/lfs_bd.h
@@ -7,6 +7,10 @@
 
 #include "lfs.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Address of the file system memory
 extern uint8_t *lfs_ptr;
 
@@ -19,5 +23,9 @@ int lfs_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off
 int lfs_erase(const struct lfs_config *c, lfs_block_t block);
 
 int lfs_sync(const struct lfs_config *c);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This change is needed for linking C++ programs with the DRAMFS library.