### PR TITLE
fix branch condition in dramfs crt0.S wait_for_sync

### DIFF
--- a/libgloss/dramfs/crt0.S
+++ b/libgloss/dramfs/crt0.S
@@ -70,7 +70,7 @@ _start:
 # Wait for hart0 to be done, then 
 wait_for_sync:
   ld t0, _sync
-  beqz t0, init_hartn
+  bnez t0, init_hartn
   j wait_for_sync
 
 init_hart0:


### PR DESCRIPTION
This fixes the branch condition in wait_for_sync to force the non-init harts (hart 1+) to wait until the init hart (hart 0) finishes initialization before proceeding with execution.